### PR TITLE
Set start script after build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.ts",
   "scripts": {
-    "start": "node dist/src/server.js",
+    "start": "node dist/server.js",
     "build": "tsc",
     "start:prod": "node dist/server.js",
     "dev": "nodemon src/server.ts",

--- a/server.log
+++ b/server.log
@@ -4,3 +4,5 @@ info: Server running on port 5003
 info: MongoDB connected
 info: Server running on port 5003
 info: MongoDB connected
+info: Server running on port 5000
+info: MongoDB connected


### PR DESCRIPTION
**Summary**

- Set the start script correctly from "./dist/src/server.js" to "./dist/server.js". This caused the docker image not to run correctly since there is no src directory after build.